### PR TITLE
#4: Implement org label sync automation across repositories

### DIFF
--- a/.github/labels/catalog.json
+++ b/.github/labels/catalog.json
@@ -1,0 +1,85 @@
+{
+  "version": 1,
+  "labels": [
+    {
+      "name": "status/backlog",
+      "color": "C5DEF5",
+      "description": "Planned work not started."
+    },
+    {
+      "name": "status/in-progress",
+      "color": "FBCA04",
+      "description": "Actively being executed."
+    },
+    {
+      "name": "status/review",
+      "color": "0E8A16",
+      "description": "Implementation complete and under review."
+    },
+    {
+      "name": "status/blocked",
+      "color": "B60205",
+      "description": "Cannot proceed due to an external dependency."
+    },
+    {
+      "name": "status/done",
+      "color": "1D76DB",
+      "description": "Completed and accepted."
+    },
+    {
+      "name": "priority/p0",
+      "color": "7A0000",
+      "description": "Critical work requiring immediate attention."
+    },
+    {
+      "name": "priority/p1",
+      "color": "B60205",
+      "description": "High priority for current milestone."
+    },
+    {
+      "name": "priority/p2",
+      "color": "D93F0B",
+      "description": "Medium priority after prerequisites."
+    },
+    {
+      "name": "priority/p3",
+      "color": "FBCA04",
+      "description": "Lower priority and deferrable."
+    },
+    {
+      "name": "type/bug",
+      "color": "D73A4A",
+      "description": "Defect affecting expected behavior."
+    },
+    {
+      "name": "type/feature",
+      "color": "A2EEEF",
+      "description": "New product or platform capability."
+    },
+    {
+      "name": "type/ops",
+      "color": "0E8A16",
+      "description": "Operational, governance, or maintenance work."
+    },
+    {
+      "name": "type/initiative",
+      "color": "1D76DB",
+      "description": "Multi-repo or program-level work."
+    },
+    {
+      "name": "work/governance",
+      "color": "5319E7",
+      "description": "Governance standards and controls."
+    },
+    {
+      "name": "work/automation",
+      "color": "0052CC",
+      "description": "Workflows and repository automation."
+    },
+    {
+      "name": "work/docs",
+      "color": "0075CA",
+      "description": "Documentation deliverables and maintenance."
+    }
+  ]
+}

--- a/.github/labels/target-repos.txt
+++ b/.github/labels/target-repos.txt
@@ -1,0 +1,3 @@
+# One repository per line in owner/name format.
+# Lines beginning with # are ignored.
+k-apps-io/.github

--- a/.github/scripts/label-sync.sh
+++ b/.github/scripts/label-sync.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CATALOG_PATH="${CATALOG_PATH:-.github/labels/catalog.json}"
+REPO_LIST_PATH="${REPO_LIST_PATH:-.github/labels/target-repos.txt}"
+REPOS_OVERRIDE="${REPOS_OVERRIDE:-}"
+DRY_RUN="${DRY_RUN:-true}"
+REPORT_PATH="${REPORT_PATH:-artifacts/label-sync-report.md}"
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Missing required command: $cmd" >&2
+    exit 1
+  fi
+}
+
+trim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+bool_lower() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+require_cmd gh
+require_cmd jq
+
+if [[ ! -f "$CATALOG_PATH" ]]; then
+  echo "Catalog file not found: $CATALOG_PATH" >&2
+  exit 1
+fi
+
+if [[ ! -f "$REPO_LIST_PATH" && -z "$REPOS_OVERRIDE" ]]; then
+  echo "Repo list file not found: $REPO_LIST_PATH" >&2
+  exit 1
+fi
+
+if ! jq -e '.labels and (.labels | type == "array")' "$CATALOG_PATH" >/dev/null; then
+  echo "Invalid catalog schema in $CATALOG_PATH (expected .labels array)." >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$REPORT_PATH")"
+timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+mode="$(bool_lower "$DRY_RUN")"
+
+declare -a repos=()
+if [[ -n "$REPOS_OVERRIDE" ]]; then
+  IFS=',' read -r -a raw_repos <<<"$REPOS_OVERRIDE"
+  for repo in "${raw_repos[@]}"; do
+    repo="$(trim "$repo")"
+    [[ -n "$repo" ]] && repos+=("$repo")
+  done
+else
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="$(trim "$line")"
+    [[ -z "$line" || "$line" == \#* ]] && continue
+    repos+=("$line")
+  done <"$REPO_LIST_PATH"
+fi
+
+if [[ "${#repos[@]}" -eq 0 ]]; then
+  echo "No target repositories were resolved." >&2
+  exit 1
+fi
+
+total_created=0
+total_updated=0
+total_unchanged=0
+total_failed=0
+
+{
+  echo "# Label Sync Report"
+  echo
+  echo "- Timestamp (UTC): $timestamp"
+  echo "- Mode: $([[ "$mode" == "true" ]] && echo "dry-run" || echo "apply")"
+  echo "- Catalog: \`$CATALOG_PATH\`"
+  echo "- Target repos: ${#repos[@]}"
+  echo
+} >"$REPORT_PATH"
+
+for repo in "${repos[@]}"; do
+  repo_created=0
+  repo_updated=0
+  repo_unchanged=0
+  repo_failed=0
+
+  echo "## $repo" >>"$REPORT_PATH"
+  echo >>"$REPORT_PATH"
+  echo "| Label | Action | Details |" >>"$REPORT_PATH"
+  echo "| --- | --- | --- |" >>"$REPORT_PATH"
+
+  if ! existing_labels="$(gh api --paginate "repos/${repo}/labels?per_page=100" 2>/dev/null | jq -s 'add // []')"; then
+    echo "| n/a | failed | Could not read labels for repository. |" >>"$REPORT_PATH"
+    echo >>"$REPORT_PATH"
+    total_failed=$((total_failed + 1))
+    continue
+  fi
+
+  while IFS= read -r label; do
+    name="$(jq -r '.name' <<<"$label")"
+    color="$(jq -r '.color' <<<"$label")"
+    description="$(jq -r '.description // ""' <<<"$label")"
+
+    existing="$(jq -c --arg n "$name" '.[] | select(.name == $n)' <<<"$existing_labels" | head -n 1 || true)"
+
+    if [[ -z "$existing" ]]; then
+      if [[ "$mode" == "true" ]]; then
+        echo "| \`$name\` | create | Missing label; would create. |" >>"$REPORT_PATH"
+      else
+        if gh label create "$name" --repo "$repo" --color "$color" --description "$description" >/dev/null 2>&1; then
+          echo "| \`$name\` | create | Created successfully. |" >>"$REPORT_PATH"
+        else
+          echo "| \`$name\` | failed | Create failed. |" >>"$REPORT_PATH"
+          repo_failed=$((repo_failed + 1))
+          total_failed=$((total_failed + 1))
+          continue
+        fi
+      fi
+      repo_created=$((repo_created + 1))
+      total_created=$((total_created + 1))
+      continue
+    fi
+
+    current_color="$(jq -r '.color // ""' <<<"$existing" | tr '[:lower:]' '[:upper:]')"
+    current_description="$(jq -r '.description // ""' <<<"$existing")"
+
+    if [[ "$current_color" == "$color" && "$current_description" == "$description" ]]; then
+      echo "| \`$name\` | unchanged | Already matches catalog. |" >>"$REPORT_PATH"
+      repo_unchanged=$((repo_unchanged + 1))
+      total_unchanged=$((total_unchanged + 1))
+      continue
+    fi
+
+    if [[ "$mode" == "true" ]]; then
+      echo "| \`$name\` | update | Drift found; would update color/description. |" >>"$REPORT_PATH"
+    else
+      if gh label edit "$name" --repo "$repo" --color "$color" --description "$description" >/dev/null 2>&1; then
+        echo "| \`$name\` | update | Updated to catalog values. |" >>"$REPORT_PATH"
+      else
+        echo "| \`$name\` | failed | Update failed. |" >>"$REPORT_PATH"
+        repo_failed=$((repo_failed + 1))
+        total_failed=$((total_failed + 1))
+        continue
+      fi
+    fi
+    repo_updated=$((repo_updated + 1))
+    total_updated=$((total_updated + 1))
+  done < <(jq -c '.labels[]' "$CATALOG_PATH")
+
+  echo >>"$REPORT_PATH"
+  echo "- Summary: created=$repo_created updated=$repo_updated unchanged=$repo_unchanged failed=$repo_failed" >>"$REPORT_PATH"
+  echo >>"$REPORT_PATH"
+done
+
+{
+  echo "## Overall Summary"
+  echo
+  echo "- Created: $total_created"
+  echo "- Updated: $total_updated"
+  echo "- Unchanged: $total_unchanged"
+  echo "- Failed: $total_failed"
+} >>"$REPORT_PATH"
+
+echo "Report written to $REPORT_PATH"
+

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -1,0 +1,54 @@
+name: Label Sync
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "If true, report-only mode without mutating labels."
+        required: true
+        type: boolean
+        default: true
+      repos:
+        description: "Optional comma-separated owner/name repos. Empty uses target-repos.txt."
+        required: false
+        type: string
+  schedule:
+    - cron: "0 13 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    name: Sync labels and publish drift report
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.ORG_LABEL_SYNC_TOKEN != '' && secrets.ORG_LABEL_SYNC_TOKEN || github.token }}
+      DRY_RUN: ${{ github.event_name == 'schedule' && 'true' || inputs.dry_run }}
+      REPOS_OVERRIDE: ${{ inputs.repos }}
+      CATALOG_PATH: .github/labels/catalog.json
+      REPO_LIST_PATH: .github/labels/target-repos.txt
+      REPORT_PATH: artifacts/label-sync-report.md
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify tooling
+        run: |
+          command -v gh
+          command -v jq
+
+      - name: Run label sync
+        run: .github/scripts/label-sync.sh
+
+      - name: Upload drift report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: label-sync-report-${{ github.run_id }}
+          path: artifacts/label-sync-report.md
+          if-no-files-found: error
+
+      - name: Publish summary
+        if: always()
+        run: cat artifacts/label-sync-report.md >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ This repository defines organization-level GitHub governance defaults for `@k-ap
 - `CONTRIBUTING.md`: standards for contributing changes.
 - `SECURITY.md`: process for reporting and handling vulnerabilities.
 - `docs/governance/`: canonical governance policies, including issue label lifecycle rules.
+- `.github/labels/`: machine-readable label catalog and default target repository list.
+- `.github/scripts/label-sync.sh`: label drift detection and sync runner.
 - `.github/ISSUE_TEMPLATE/`: baseline issue templates.
 - `.github/pull_request_template.md`: default PR checklist.
 - `.github/workflows/`: CI workflows for markdown and link validation.

--- a/docs/governance/label-sync-automation.md
+++ b/docs/governance/label-sync-automation.md
@@ -1,0 +1,67 @@
+# Label Sync Automation
+
+This document defines how label synchronization is executed and safely operated.
+
+## Purpose
+
+- Keep canonical labels consistent across target repositories.
+- Detect drift in label name, color, and description.
+- Support low-risk rollout with dry-run reporting before apply mode.
+
+## Source of Truth
+
+- Label catalog: `.github/labels/catalog.json`
+- Default target repositories: `.github/labels/target-repos.txt`
+- Workflow: `.github/workflows/label-sync.yml`
+- Sync script: `.github/scripts/label-sync.sh`
+
+## Execution Modes
+
+- Scheduled run (weekly): always dry-run.
+- Manual run (`workflow_dispatch`):
+  - `dry_run=true` for audit-only reporting
+  - `dry_run=false` to apply create/update changes
+- Optional repo override:
+  - Use comma-separated `owner/name` values in dispatch input `repos`
+  - Leave empty to use `target-repos.txt`
+
+## Required Token and Permissions
+
+Set secret `ORG_LABEL_SYNC_TOKEN` in this repository.
+
+Recommended scopes:
+
+- `repo` for private repositories
+- `public_repo` for public-only repositories
+- `read:org` if needed for organization visibility checks
+
+If `ORG_LABEL_SYNC_TOKEN` is absent, the workflow falls back to `GITHUB_TOKEN`,
+which is generally insufficient for cross-repo synchronization.
+
+## Drift Report and Audit Trail
+
+Each run writes a markdown report at `artifacts/label-sync-report.md` and uploads
+it as a workflow artifact.
+
+The report includes:
+
+- execution mode (dry-run/apply)
+- repository-by-repository actions
+- per-label action (`create`, `update`, `unchanged`, `failed`)
+- overall totals
+
+## Safe Change and Rollback Guidance
+
+1. Always run a dry-run first against the full target repo list.
+2. Review the report for unexpected updates.
+3. Apply to one low-risk repository first using dispatch `repos=<single repo>`.
+4. Apply to full set only after pilot success.
+5. If incorrect changes are applied:
+   - Revert the catalog change in a PR.
+   - Re-run in apply mode to restore prior color/description values.
+   - If needed, patch a specific repo label manually with `gh label edit`.
+
+## Non-Goals
+
+- Deleting unmanaged labels from target repositories.
+- Enforcing issue transition rules (handled by guardrail automation in issue #5).


### PR DESCRIPTION
Implements issue #4.

## Scope
- Add machine-readable label catalog and default target repo list
- Add sync script supporting dry-run and apply modes
- Add scheduled + manual workflow for drift reporting/sync
- Add operational docs including token requirements and rollback guidance

## Validation
- Local dry-run: Report written to artifacts/label-sync-report.md generated drift report successfully
-  passed

Closes #4