### PR TITLE
#3: Add standard bug/feature issue forms and override guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,67 @@
+name: Bug report
+description: Report a defect affecting expected behavior
+title: "[Bug] "
+labels:
+  - type/bug
+  - status/backlog
+  - priority/p2
+body:
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      description: One-line description of the bug.
+      placeholder: Describe the defect.
+    validations:
+      required: true
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: Who is affected and how severe is the impact?
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Runtime, platform, version, or repository context.
+      placeholder: |
+        - Environment:
+        - Version/commit:
+        - Affected area:
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Reproduction steps
+      description: Minimal steps to reproduce.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      placeholder: |
+        - [ ] Reproduction no longer fails
+        - [ ] Regression risk validated
+    validations:
+      required: true
+

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,58 @@
+name: Feature request
+description: Propose and plan new product/platform capability
+title: "[Feature] "
+labels:
+  - type/feature
+  - status/backlog
+  - priority/p2
+body:
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      description: One-line statement of the feature.
+      placeholder: Describe the feature.
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What problem is this solving?
+    validations:
+      required: true
+  - type: textarea
+    id: goals
+    attributes:
+      label: Goals and non-goals
+      placeholder: |
+        Goals:
+        - ...
+        Non-goals:
+        - ...
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: Functional scope, dependencies, and constraints.
+    validations:
+      required: true
+  - type: textarea
+    id: rollout
+    attributes:
+      label: Rollout and risk
+      description: Rollout plan, risk level, and rollback strategy.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This repository defines organization-level GitHub governance defaults for `@k-ap
 - `.github/scripts/label-sync.sh`: label drift detection and sync runner.
 - `.github/scripts/status-guardrails.sh`: status transition and conflict enforcement.
 - `docs/governance/org-rollout-plan.md`: rollout waves, owners, metrics, and timelines.
+- `docs/governance/template-adoption-and-overrides.md`: template precedence and override rules.
 - `.github/ISSUE_TEMPLATE/`: baseline issue templates.
 - `.github/pull_request_template.md`: default PR checklist.
 - `.github/workflows/`: CI workflows for markdown and link validation.

--- a/docs/governance/template-adoption-and-overrides.md
+++ b/docs/governance/template-adoption-and-overrides.md
@@ -1,0 +1,56 @@
+# Template Adoption and Override Rules
+
+This document explains how repositories in `@k-apps-io` adopt or override
+organization defaults from `k-apps-io/.github`.
+
+## Org Default Templates
+
+Default templates provided by this repository:
+
+- `.github/ISSUE_TEMPLATE/bug.yml`
+- `.github/ISSUE_TEMPLATE/feature.yml`
+- `.github/ISSUE_TEMPLATE/governance-task.yml`
+- `.github/pull_request_template.md`
+
+## Resolution and Precedence
+
+GitHub resolves templates with this precedence:
+
+1. Repository-local templates in `<target-repo>/.github/`
+2. Organization-level defaults in `k-apps-io/.github`
+
+Practical result:
+
+- If a target repository defines its own issue forms or PR template, the repo
+  local files take precedence.
+- If a target repository has no local template for a type, org defaults apply.
+
+## Adoption (Recommended Default Path)
+
+For repositories that should inherit org defaults:
+
+1. Do not add local duplicates of these files:
+   - `<target-repo>/.github/ISSUE_TEMPLATE/bug.yml`
+   - `<target-repo>/.github/ISSUE_TEMPLATE/feature.yml`
+   - `<target-repo>/.github/pull_request_template.md`
+2. Keep org-level templates current in `k-apps-io/.github`.
+3. Verify template availability in the target repository issue/PR UI.
+
+## Override (When Repo-Specific Customization Is Needed)
+
+Allowed override pattern:
+
+1. Copy the org default file into the target repo:
+   - `k-apps-io/.github/.github/ISSUE_TEMPLATE/bug.yml` ->
+     `<target-repo>/.github/ISSUE_TEMPLATE/bug.yml`
+2. Keep the canonical labels in defaults:
+   - `type/*`, `status/backlog`, and `priority/*`
+3. Add only repo-specific fields required by that repository.
+4. Document why the override exists in target repo `README` or `CONTRIBUTING`.
+
+## Validation Checklist
+
+- New issues created from `bug` and `feature` forms apply default labels.
+- PR template appears when opening pull requests.
+- Required metadata fields are present in created issues.
+- Overrides remain compatible with org label taxonomy.


### PR DESCRIPTION
Implements issue #3.

## Scope
- Add standard issue forms for bug and feature work
- Keep governance-task template as task/process path
- Ensure default labels are embedded in each form
- Add adoption/override guidance with explicit file precedence

## Validation
- `markdownlint-cli2 "**/*.md"` passed
- Issue form files added under `.github/ISSUE_TEMPLATE/`

Closes #3
